### PR TITLE
fix: Shave a MB or 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ iso: all
 	mkdir -p $(BUILD_DIR)/iso/boot/grub
 	cp assets/grub.cfg $(BUILD_DIR)/iso/boot/grub
 	cp $(BUILD_DIR)/kernel.bin $(BUILD_DIR)/iso/boot/
-	grub-mkrescue -v -o $(BUILD_DIR)/$(NAME).iso $(BUILD_DIR)/iso --compress=xz
+	grub-mkrescue -v -o $(BUILD_DIR)/$(NAME).iso $(BUILD_DIR)/iso --compress=xz --locale-directory=/dev/null --fonts=ascii
 
 run: iso
 	qemu-system-i386 -cdrom $(BUILD_DIR)/$(NAME).iso -boot d


### PR DESCRIPTION
Shave a few MB, by kicking out the unicode font and not including locales.
Happy to help! @FelixBrgm

<img width="533" alt="{6DE0F133-189E-4F96-A780-BBCF607D1BF6}" src="https://github.com/user-attachments/assets/a87c231a-0239-4dd4-b354-96e27ca1ec2a">

Built in dev container. Somehow when building in WSL ubuntu i get a file thats 2MB, idk whats up with that. Might be worth investigating.
<img width="535" alt="{6B6DEA01-5794-42C1-9261-EBBFA4CFD582}" src="https://github.com/user-attachments/assets/521c5471-0e82-4491-8785-51d05438a9f1">
