### PR TITLE
Clean up `.cargo/config.toml` to allow calling `cargo build` without parameters

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
-[alias]
-build-kernel = "build -Zbuild-std=core,alloc --target=.cargo/i386-unknown-none.json --release"
+[unstable]
+build-std = ["core", "alloc", "compiler_builtins"]
+build-std-features = ["compiler-builtins-mem"]
 
-[target."i386-unknown-none"]
-rustflags = ["-Zreg-struct-return", "-Zregparm=3"]
+[build]
+target = "./.cargo/i386-unknown-none.json"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ $(BUILD_DIR)/$(GDT_OBJ): $(GDT) | $(BUILD_DIR)
 	as --32 -o $@ $<
 
 $(LIB): $(RUST_SRCS) $(CARGO_TOML) $(MULTIBOOT_HEADER)
-	cargo build-kernel
+	cargo build --release
 	touch $(LIB)
 
 $(BUILD_DIR):


### PR DESCRIPTION
Our build process previously involved calling a custom `cargo build-kernel` alias, which expanded to `cargo build -Zbuild-std=core,alloc --target=./.cargo/i386-unknown-none.json --release`.

I configured `.cargo/config.toml` to get all this information automatically when building, so the build command in our Makefile could only be `cargo build --release`.

I removed some flags I had added (`-Zreg-struct-return`, which allows small structs up to size 8 to be returned in registers, and `-Zregparm=3`, which allows up to 3 function parameters to be passed in registers instead of the stack, as is convention in i386), I think it's not a good idea to be messing with the ABI at this stage, we can add them back later if we feel the need to.

I also added the `compiler-builtins-mem`, which [enables the `#[unsafe(no_mangle)]` attribute on compiler intrinsics like `memcpy`](https://github.com/rust-lang/compiler-builtins/blob/eff506cd49b637f1ab5931625a33cef7e91fbbf6/src/mem.rs#L12-L69) to make them available to the linker.